### PR TITLE
Fix to missing object in loader.php

### DIFF
--- a/MailLibrary/loader.php
+++ b/MailLibrary/loader.php
@@ -6,23 +6,24 @@
 require_once "exceptions.php";
 
 spl_autoload_register(function ($type) {
-	static $paths = array(
-		'greeny\maillibrary\connection' => 'Connection.php',
-		'greeny\maillibrary\mailbox' => 'Mailbox.php',
-		'greeny\maillibrary\selection' => 'Selection.php',
-		'greeny\maillibrary\mail' => 'Mail.php',
-		'greeny\maillibrary\contactlist' => 'ContactList.php',
-		'greeny\maillibrary\attachment' => 'Attachment.php',
-		'greeny\maillibrary\structures\istructure' => 'Structures/IStructure.php',
-		'greeny\maillibrary\structures\imapstructure' => 'Structures/ImapStructure.php',
-		'greeny\maillibrary\drivers\idriver' => 'Drivers/IDriver.php',
-		'greeny\maillibrary\drivers\imapdriver' => 'Drivers/ImapDriver.php',
-		'greeny\maillibrary\extensions\maillibraryextension' => 'Extensions/MailLibraryExtension.php',
-	);
+        static $paths = array(
+            'greeny\maillibrary\connection' => 'Connection.php',
+            'greeny\maillibrary\mailbox' => 'Mailbox.php',
+            'greeny\maillibrary\selection' => 'Selection.php',
+            'greeny\maillibrary\mail' => 'Mail.php',
+            'greeny\maillibrary\contactlist' => 'ContactList.php',
+            'greeny\maillibrary\contact' => 'Contact.php',
+            'greeny\maillibrary\attachment' => 'Attachment.php',
+            'greeny\maillibrary\structures\istructure' => 'Structures/IStructure.php',
+            'greeny\maillibrary\structures\imapstructure' => 'Structures/ImapStructure.php',
+            'greeny\maillibrary\drivers\idriver' => 'Drivers/IDriver.php',
+            'greeny\maillibrary\drivers\imapdriver' => 'Drivers/ImapDriver.php',
+            'greeny\maillibrary\extensions\maillibraryextension' => 'Extensions/MailLibraryExtension.php',
+        );
 
-	$type = ltrim(strtolower($type), '\\'); // PHP namespace bug #49143
+        $type = ltrim(strtolower($type), '\\'); // PHP namespace bug #49143
 
-	if (isset($paths[$type])) {
-		require_once __DIR__ . '/' . $paths[$type];
-	}
+        if (isset($paths[$type])) {
+                require_once __DIR__ . '/' . $paths[$type];
+        }
 });


### PR DESCRIPTION
There was a missing object "Contact" in loader.php. 
This produced an Error "Cound not find object of class greeny\MailLibrary\Contact" when adding a contact to a contact list.

My environment id PHP 5.6 and Linux Debian operating system.
