### PR TITLE
Bug fixes

### DIFF
--- a/MailLibrary/ContactList.php
+++ b/MailLibrary/ContactList.php
@@ -11,9 +11,9 @@ use Countable;
 class ContactList implements Iterator, Countable
 {
 	/** @var Contact[] */
-	protected $contacts;
+	protected $contacts = [];
 
-	protected $builtContacts;
+	protected $builtContacts = [];
 
 	public function addContact($mailbox = NULL, $host = NULL, $personal = NULL, $adl = NULL)
 	{

--- a/MailLibrary/Mail.php
+++ b/MailLibrary/Mail.php
@@ -124,7 +124,12 @@ class Mail {
 	public function getHeader($name)
 	{
 		$this->headers !== NULL || $this->initializeHeaders();
-		return $this->headers[$this->formatHeaderName($name)];
+		$index = $this->formatHeaderName($name);
+		if(isset($this->headers[$index])) {
+			return $this->headers[$index];
+		} else {
+			return NULL;
+		}
 	}
 
 	/**

--- a/MailLibrary/loader.php
+++ b/MailLibrary/loader.php
@@ -6,24 +6,24 @@
 require_once "exceptions.php";
 
 spl_autoload_register(function ($type) {
-        static $paths = array(
-            'greeny\maillibrary\connection' => 'Connection.php',
-            'greeny\maillibrary\mailbox' => 'Mailbox.php',
-            'greeny\maillibrary\selection' => 'Selection.php',
-            'greeny\maillibrary\mail' => 'Mail.php',
-            'greeny\maillibrary\contactlist' => 'ContactList.php',
-            'greeny\maillibrary\contact' => 'Contact.php',
-            'greeny\maillibrary\attachment' => 'Attachment.php',
-            'greeny\maillibrary\structures\istructure' => 'Structures/IStructure.php',
-            'greeny\maillibrary\structures\imapstructure' => 'Structures/ImapStructure.php',
-            'greeny\maillibrary\drivers\idriver' => 'Drivers/IDriver.php',
-            'greeny\maillibrary\drivers\imapdriver' => 'Drivers/ImapDriver.php',
-            'greeny\maillibrary\extensions\maillibraryextension' => 'Extensions/MailLibraryExtension.php',
-        );
+	static $paths = array(
+		'greeny\maillibrary\connection' => 'Connection.php',
+		'greeny\maillibrary\mailbox' => 'Mailbox.php',
+		'greeny\maillibrary\selection' => 'Selection.php',
+		'greeny\maillibrary\mail' => 'Mail.php',
+		'greeny\maillibrary\contactlist' => 'ContactList.php',
+		'greeny\maillibrary\contact' => 'Contact.php',
+		'greeny\maillibrary\attachment' => 'Attachment.php',
+		'greeny\maillibrary\structures\istructure' => 'Structures/IStructure.php',
+		'greeny\maillibrary\structures\imapstructure' => 'Structures/ImapStructure.php',
+		'greeny\maillibrary\drivers\idriver' => 'Drivers/IDriver.php',
+		'greeny\maillibrary\drivers\imapdriver' => 'Drivers/ImapDriver.php',
+		'greeny\maillibrary\extensions\maillibraryextension' => 'Extensions/MailLibraryExtension.php',
+	);
 
-        $type = ltrim(strtolower($type), '\\'); // PHP namespace bug #49143
+	$type = ltrim(strtolower($type), '\\'); // PHP namespace bug #49143
 
-        if (isset($paths[$type])) {
-                require_once __DIR__ . '/' . $paths[$type];
-        }
+	if (isset($paths[$type])) {
+		require_once __DIR__ . '/' . $paths[$type];
+	}
 });

--- a/README.md
+++ b/README.md
@@ -4,3 +4,16 @@ MailLibrary
 A PHP library for downloading mails from server.
 
 Documentation can be found at http://greeny.github.io/MailLibrary/.
+
+Testing
+-------
+
+Install dependencies using composer and then run following in library root directory.
+
+````cmd
+# Unix
+vendor\bin\tester -c tests\php-unix.ini tests
+
+# Windows
+vendor\bin\tester -c tests\php-windows.ini tests
+````

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
     },
     "require": {
         "php": ">= 5.3.0",
-        "ext-imap": "*"
+        "ext-imap": "*",
+        "nette/utils": "~2.2"
     },
     "require-dev": {
         "nette/tester": "@dev"

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
         "files": ["MailLibrary/loader.php"]
     },
     "require": {
-        "php": ">= 5.3.0"
+        "php": ">= 5.3.0",
+        "ext-imap": "*"
     },
     "require-dev": {
         "nette/tester": "@dev"

--- a/tests/php-unix.ini
+++ b/tests/php-unix.ini
@@ -1,0 +1,5 @@
+[PHP]
+;extension_dir = "./ext"
+extension=mbstring.so
+extension=imap.so
+date.timezone = "Europe/Prague"

--- a/tests/php-windows.ini
+++ b/tests/php-windows.ini
@@ -1,0 +1,5 @@
+[PHP]
+extension_dir = "./ext"
+extension=php_mbstring.dll
+extension=php_imap.dll
+date.timezone = "Europe/Prague"


### PR DESCRIPTION
Hi! I've been migrating around 500GB of e-mails using this library. Thanks for this library you've saved me a lot of time.

However on this amount of data some unhandled edge cases poped up. This PR is summary of what was broken. There is also another PR which proposes bigger changes, which requires some more work before merging. (#14)

what has been changed:
- introduces config files for tester (and updated readme.md)
- Mail::getHeader() now returns NULL if header does not exist (does not make notice warnings anymore)
- ImapDriver: properly handles long headers (that splits over more lines)
- ImapDriver: normalizes and fixes UTF-8 encoding in mail headers
- composer: added imap extension as dependency
- composer: added Nette\utils as dependency because it helps a lot with fixing, normalizing, etc. UTF-8 strings

TODO:
- [ ] There are strill some notices thrown from PHP imap extension in some cases (wasn't able to reproduce)
- [ ] This implies another question - don't you want to use IMAP client implementation without PHP IMAP extension? (see #14 why)
